### PR TITLE
Fix template in config generator

### DIFF
--- a/bandit/cli/config_generator.py
+++ b/bandit/cli/config_generator.py
@@ -43,10 +43,10 @@ template = """
 # Available tests:
 {test_list}
 
-# (optional) list included test IDs here, eg '[B101, B406]':
+# (optional) list included test IDs here, eg ['B101', 'B406']:
 {test}
 
-# (optional) list skipped test IDs here, eg '[B101, B406]':
+# (optional) list skipped test IDs here, eg ['B101', 'B406']:
 {skip}
 
 ### (optional) plugin settings - some test plugins require configuration data


### PR DESCRIPTION
Comments in the config generator template were not consistent
with the docs, and the yaml format.
