### PR TITLE
Add support to run bandit as python -m bandit

### DIFF
--- a/bandit/__main__.py
+++ b/bandit/__main__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+from bandit.cli import main
+main.main()


### PR DESCRIPTION
This way we can easly choose which python to run:
python -m bandit
python3 -b bandit
