### PR TITLE
Log the version of Python used in the scan

### DIFF
--- a/bandit/formatters/json.py
+++ b/bandit/formatters/json.py
@@ -174,6 +174,7 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
 
     time_string = datetime.datetime.utcnow().strftime(TS_FORMAT)
     machine_output['generated_at'] = time_string
+    machine_output['python_version'] = '.'.join(map(str, sys.version_info[:3]))
 
     result = json.dumps(machine_output, sort_keys=True,
                         indent=2, separators=(',', ': '))

--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -157,7 +157,8 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
     """
 
     bits = []
-    bits.append(header("Run started:%s", datetime.datetime.utcnow()))
+    bits.append(header("Run started: %s", datetime.datetime.utcnow()))
+    bits.append(header("Python version: %s" % '.'.join(map(str, sys.version_info[:3]))))
 
     if manager.verbose:
         bits.append(get_verbose_details(manager))

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -135,7 +135,8 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
     """
 
     bits = []
-    bits.append("Run started:%s" % datetime.datetime.utcnow())
+    bits.append("Run started: %s" % datetime.datetime.utcnow())
+    bits.append("Python version: %s" % '.'.join(map(str, sys.version_info[:3])))
 
     if manager.verbose:
         bits.append(get_verbose_details(manager))


### PR DESCRIPTION
This Pull Request adds logging of the version of Python that was used to run the scan to the txt, json and screen formatters. This is helpful when running bandit with different Python versions and storing the reports for later.

To see the changes use one of the updated formatters. Example usage:

```
python -m bandit.cli.main -f txt ~/tmp/badcode.py
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 2.7.12
Run started: 2016-10-26 23:56:31.078485
Python version: 2.7.12

Test results:
    No issues identified.

Code scanned:
    Total lines of code: 2
    Total lines skipped (#nosec): 0

Run metrics:
    Total issues (by severity):
        Undefined: 0
        Low: 0
        Medium: 0
        High: 0
    Total issues (by confidence):
        Undefined: 0
        Low: 0
        Medium: 0
        High: 0
Files skipped (0):
```
