### PR TITLE
Fixing parameter retrieval bug in weak_cryptographic_key.py

### DIFF
--- a/bandit/plugins/weak_cryptographic_key.py
+++ b/bandit/plugins/weak_cryptographic_key.py
@@ -96,7 +96,8 @@ def _weak_crypto_key_size_cryptography_io(context):
             'SECT163K1': 163,
             'SECT163R2': 163,
         }
-        curve = context.call_args[arg_position[key_type]]
+        curve = (context.get_call_arg_value('curve') or
+                 context.get_call_arg_at_position(arg_position[key_type]))
         key_size = curve_key_sizes[curve] if curve in curve_key_sizes else 224
         return _classify_key_size(key_type, key_size)
 


### PR DESCRIPTION
fix to enable checks on calls to ec.generate_private_key with named parameter for curve

Prior to this change, if bandit were run over a codebase containing a call to ec.generate_private_key which specified the curve with a named parameter, bandit would throw an IndexError.