### PR TITLE
Updates to SQL injection plugin

### DIFF
--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -80,7 +80,10 @@ def _check_string(data):
 
 
 def _evaluate_ast(node):
-    if not isinstance(node.parent, ast.BinOp):
+    mod_format = isinstance(node.parent, ast.BinOp)
+    str_format = isinstance(node.parent, ast.Attribute) and \
+                 node.parent.attr == 'format'
+    if not mod_format and not str_format:
         return (False, "")
 
     out = utils.concat_string(node, node.parent)

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -60,18 +60,23 @@ If so, a MEDIUM issue is reported. For example:
 """
 
 import ast
+import re
 
 import bandit
 from bandit.core import test_properties as test
 from bandit.core import utils
 
+SIMPLE_SQL_RE = re.compile(
+    r'(select\s.*from\s|' \
+    r'delete\s+from\s|' \
+    r'insert\s+into\s.*values\s|' \
+    r'update\s.*set\s)',
+    re.IGNORECASE | re.DOTALL,
+)
+
 
 def _check_string(data):
-    val = data.lower()
-    return ((val.startswith('select ') and ' from ' in val) or
-            val.startswith('insert into') or
-            (val.startswith('update ') and ' set ' in val) or
-            val.startswith('delete from '))
+    return SIMPLE_SQL_RE.search(data) is not None
 
 
 def _evaluate_ast(node):


### PR DESCRIPTION
This should catch and warn on a few extra cases, namely SQL queries that are constructed in a different manner whereby the main operator isn't first and the usage of str.format.

```
The previous version assumed the SQL query would start with `select`,
`insert into`, `update` or `delete from` which rules out queries that
are not so simple, for example queries using `with` such as:

   WITH cte AS (query)
   SELECT something FROM cte;

This version losens the criteria and considers any string with simple
SQL grammar (e.g. `select` followed by `from` anywhere within) as SQL.
```

```
This considers `"{}".format()` style alongside `"%s" % ` string
formatting for possible SQL injection vulnerabilities.
```
(If this is useful I'll look into considering Python 3.6 fstrings in the same light).