### PR TITLE
updated documentation url on docs.openstack.org

### DIFF
--- a/bandit/core/docs_utils.py
+++ b/bandit/core/docs_utils.py
@@ -15,7 +15,7 @@
 # under the License.
 
 # where our docs are hosted
-BASE_URL = 'https://docs.openstack.org/developer/bandit/'
+BASE_URL = 'https://docs.openstack.org/bandit/latest/'
 
 
 def get_url(bid):


### PR DESCRIPTION
The directory structure on docs.openstack.org has changed and broke the urls
https://docs.openstack.org/developer/bandit/plugins/try_except_pass.html is no longer active and redirects to https://docs.openstack.org/bandit/latest/