### PR TITLE
Reducing false positives for yaml.load

### DIFF
--- a/bandit/plugins/yaml_load.py
+++ b/bandit/plugins/yaml_load.py
@@ -59,7 +59,8 @@ def yaml_load(context):
         qualname_list = context.call_function_name_qual.split('.')
         func = qualname_list[-1]
         if 'yaml' in qualname_list and func == 'load':
-            if not context.check_call_arg_value('Loader', 'SafeLoader'):
+            if not context.check_call_arg_value('Loader', 'SafeLoader') and \
+                    not context.check_call_arg_value('Loader', 'CSafeLoader'):
                 return bandit.Issue(
                     severity=bandit.MEDIUM,
                     confidence=bandit.HIGH,


### PR DESCRIPTION
### Description

The previous check allows for the use of `yaml.load` in the following fashion:

```
yaml.load(data, Loader=SafeLoader)
```

However, we should not penalize (and falsely alert) users for using the faster version of SafeLoader, `CSafeLoader`. This is an [example of CSafeLoader being used](https://github.com/dnephin/PyStaticConfiguration/blob/c84ccddb4298d39b52d14989d68deee818c39aab/staticconf/loader.py#L161).

### Fix

Just whitelist it as well.